### PR TITLE
Remove trailing slash from URL path

### DIFF
--- a/lib/classlink_client/request_builder.rb
+++ b/lib/classlink_client/request_builder.rb
@@ -39,6 +39,7 @@ module ClassLink
 
     def build_url
       URI.join(base_url, *@path_parts).tap do |url|
+        url.path = url.path[..-2]
         url.query = @query.to_query
       end
     end


### PR DESCRIPTION
This caused filter params to be ignored